### PR TITLE
Remove current banner reference during raffle creation

### DIFF
--- a/app/Controllers/Admin/RafflesController.php
+++ b/app/Controllers/Admin/RafflesController.php
@@ -60,9 +60,7 @@ class RafflesController extends Controller {
         if (!is_dir($imgDir)) { @mkdir($imgDir, 0775, true); }
         $dest  = $imgDir . '/' . $fname;
         if (move_uploaded_file($_FILES['banner']['tmp_name'], $dest)) {
-          $old = $current['banner_path'] ?? null;
           $data['banner_path'] = '/images/' . $fname;
-          if ($old && is_string($old)) { $oldPath = PUBLIC_PATH . $old; if (is_file($oldPath)) { @unlink($oldPath); } }
         }
       }
     }


### PR DESCRIPTION
## Summary
- Avoid reference to nonexistent `$current` during banner upload in raffle creation.
- Preserve logic that stores new banner path when file upload succeeds.

## Testing
- `php -l app/Controllers/Admin/RafflesController.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4a2d9400c8324a7bfb412f19c67f6