### PR TITLE
Show confirmation after payment receipt upload

### DIFF
--- a/app/Controllers/OrderController.php
+++ b/app/Controllers/OrderController.php
@@ -55,8 +55,8 @@ $r = new Raffle(); $t = new Ticket(); $o = new Order(); $s = new Setting(); $a =
       $this->redirect('/orden/' . $code);
     } catch (Throwable $e) {
       $this->view('public/error.php', ['message'=>'No fue posible crear la orden. Intente de nuevo.']);
-    }
   }
+}
 
   public function show($code) {
     // Liberar reservas expiradas automáticamente
@@ -114,7 +114,7 @@ if (!empty($_FILES['receipt']['name'])) {
       'reference'=>$reference, 'receipt_path'=>$receipt_path
     ]);
     (new Activity())->log(null,'create','payment',$pid,"Pago registrado para orden {$order['code']}",['reference'=>$reference]);
-    $this->redirect('/orden/' . $code);
+    $this->redirect('/orden/' . $code . '?uploaded=1');
   }
 
   public function receiptHtml($code) {

--- a/app/Views/public/order_show.php
+++ b/app/Views/public/order_show.php
@@ -27,7 +27,16 @@
       </tr>
     <?php endforeach; ?>
   </table>
-</div>
+  </div>
+<?php if (!empty($_GET['uploaded'])): ?>
+  <style>
+    .alert-success{margin:8px 0 12px;padding:10px 12px;border:1px solid var(--success);background:rgba(52,211,153,.15);color:var(--success);border-radius:12px;}
+  </style>
+  <div class="alert-success" id="paymentUploadedMsg">¡Comprobante recibido! Está en revisión.</div>
+  <script>
+    setTimeout(function(){ var el=document.getElementById('paymentUploadedMsg'); if(el){ el.style.display='none'; } }, 5000);
+  </script>
+<?php endif; ?>
 <div class="card">
   <h3>Pago</h3>
   <style>


### PR DESCRIPTION
## Summary
- Redirect back to order page with `uploaded=1` after submitting a payment receipt.
- Display a temporary success alert on the order page when the receipt flag is present.

## Testing
- `php -l app/Controllers/OrderController.php`
- `php -l app/Views/public/order_show.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4a6feabdc83248468ced44b181ff0