### PR TITLE
Evitar pagos para órdenes procesadas

### DIFF
--- a/app/Controllers/OrderController.php
+++ b/app/Controllers/OrderController.php
@@ -79,6 +79,10 @@ $r = new Raffle(); $t = new Ticket(); $o = new Order(); $s = new Setting(); $a =
     $o = new Order();
     $order = $o->findByCode($code);
     if (!$order) { $this->view('public/error.php',['message'=>'Orden inválida']); return; }
+    if ($order['status'] !== 'pendiente') {
+      $this->view('public/error.php',['message'=>'La orden ya no acepta pagos']);
+      return;
+    }
 
     $method = $_POST['method'] ?? 'pago_movil';
     $amount_ves = floatval($_POST['amount_ves'] ?? 0);

--- a/app/Views/public/order_show.php
+++ b/app/Views/public/order_show.php
@@ -30,6 +30,7 @@
 </div>
 <div class="card">
   <h3>Pago</h3>
+  <?php if ($order['status'] === 'pendiente'): ?>
   <style>
   /* paydetails styles */
   .paybox{margin-top:8px; padding:10px 12px; border:1px solid #eee; border-radius:12px; background:#fafafa}
@@ -92,6 +93,17 @@
     </div>
     <p><button class="btn btn-primary">Enviar pago</button></p>
   </form>
+  <?php else: ?>
+  <div style="margin:8px 0 0 0; padding:10px 12px; border:1px solid #fecaca; background:#fee2e2; color:#b91c1c; border-radius:12px;">
+    <?php if ($order['status'] === 'aprobado'): ?>
+      Esta orden ya fue aprobada. ¡Gracias por tu pago!
+    <?php elseif ($order['status'] === 'rechazado'): ?>
+      Esta orden fue rechazada. Si crees que es un error, contacta al soporte.
+    <?php else: ?>
+      Esta orden ya no está pendiente.
+    <?php endif; ?>
+  </div>
+  <?php endif; ?>
   <?php if (!empty($payments)): ?>
     <h4>Pagos enviados</h4>
     <ul>


### PR DESCRIPTION
## Summary
- Solo mostrar el formulario de pago cuando la orden está pendiente y mostrar aviso si fue aprobada o rechazada.
- Rechazar cargas de comprobantes cuando la orden ya no está pendiente.

## Testing
- `php -l app/Views/public/order_show.php`
- `php -l app/Controllers/OrderController.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4a6fd72108324a343794449a58857