### PR TITLE
Mostrar pagos en tabla con etiquetas y miniaturas

### DIFF
--- a/app/Views/public/order_show.php
+++ b/app/Views/public/order_show.php
@@ -94,11 +94,34 @@
   </form>
   <?php if (!empty($payments)): ?>
     <h4>Pagos enviados</h4>
-    <ul>
-    <?php foreach ($payments as $p): ?>
-      <li><?=$p['method']?> — <?=$p['status']?> — ref: <?=Utils::e($p['reference'])?> <?php if($p['receipt_path']): ?> — <a href="/file/receipt/<?=Utils::e($p['receipt_path'])?>">ver archivo</a><?php endif; ?></li>
-    <?php endforeach; ?>
-    </ul>
+    <table class="table">
+      <tr>
+        <th>Método</th>
+        <th>Estado</th>
+        <th>Referencia</th>
+        <th>Comprobante</th>
+      </tr>
+      <?php foreach ($payments as $p):
+        $stClass = [
+          'pendiente' => 'badge-warning',
+          'aprobado' => 'badge-success',
+          'rechazado' => 'badge-danger'
+        ][$p['status']] ?? 'badge';
+      ?>
+        <tr>
+          <td><?=Utils::e($p['method'])?></td>
+          <td><span class="badge <?=$stClass?>"><?=Utils::e($p['status'])?></span></td>
+          <td><?=Utils::e($p['reference'])?></td>
+          <td>
+            <?php if ($p['receipt_path']): ?>
+              <img src="/file/receipt/<?=Utils::e($p['receipt_path'])?>" alt="Comprobante" class="receipt-thumb">
+            <?php else: ?>
+              —
+            <?php endif; ?>
+          </td>
+        </tr>
+      <?php endforeach; ?>
+    </table>
   <?php endif; ?>
 </div>
 
@@ -249,6 +272,13 @@
       }
     });
   }
+
+  document.querySelectorAll('.receipt-thumb').forEach(function(img){
+    img.addEventListener('click', function(){
+      dataUrl = this.src;
+      openModal();
+    });
+  });
 })();
 </script>
 

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -150,6 +150,12 @@ a:hover{color:#1e40af}
   border-radius:999px;
 }
 
+.badge-success,.tag-success{background:var(--success);color:#fff;border:1px solid var(--success);}
+.badge-warning,.tag-warning{background:var(--warning);color:#fff;border:1px solid var(--warning);}
+.badge-danger,.tag-danger{background:var(--danger);color:#fff;border:1px solid var(--danger);}
+
+.receipt-thumb{height:40px;border-radius:6px;cursor:pointer;box-shadow:0 1px 4px rgba(0,0,0,.15);}
+
 .nav, .site-header{
   background:rgba(255,255,255,.7);
   border-bottom:1px solid var(--border);


### PR DESCRIPTION
## Resumen
- Reemplazo de la lista de pagos por una tabla con método, estado, referencia y comprobante.
- Etiquetas coloreadas para estado y miniaturas del comprobante reutilizando la vista previa.
- Estilos CSS para badges y miniaturas.

## Pruebas
- `php -l app/Views/public/order_show.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4a6fd077c8324a8f854f2ec895462