### PR TITLE
Add server-based expiry countdown with progress bar

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -26,6 +26,8 @@ a{color:var(--accent);text-decoration:none}
 .badge{display:inline-block;padding:6px 10px;border-radius:999px;background:rgba(255,255,255,.08);border:1px solid var(--border);color:var(--muted);font-size:12px}
 .progress{background:rgba(255,255,255,.08);height:12px;border-radius:999px;overflow:hidden;border:1px solid var(--border);margin:10px 0 8px 0}
 .progress>span{display:block;height:100%;background:linear-gradient(90deg,#2dd4bf,#22c55e)}
+.cd-progress{height:8px;margin-top:6px;background:var(--border);border-radius:999px;overflow:hidden}
+.cd-progress span{display:block;height:100%;width:100%;background:linear-gradient(90deg,var(--accent),var(--success));transition:width 1s linear}
 .input, select, textarea{width:100%;padding:10px 12px;border-radius:12px;border:1px solid var(--border);background:rgba(255,255,255,.06);color:var(--txt);outline:none}
 label{font-size:13px;color:var(--muted);margin-bottom:6px;display:block}
 .form-row{display:grid;grid-template-columns:1fr 1fr;gap:12px}


### PR DESCRIPTION
## Summary
- Derive order expiration from server timestamp and expose via `data-expiry`
- Compute countdown and progress bar client-side from server expiry to avoid clock drift
- Style countdown progress indicator in CSS for polished look

## Testing
- `php -l app/Views/public/order_show.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4a6fb45d48324b67cebfa262d263f