### PR TITLE
Add payment security notice and verification tooltip

### DIFF
--- a/app/Views/public/order_show.php
+++ b/app/Views/public/order_show.php
@@ -49,6 +49,7 @@
   .modal-close{position:absolute; top:6px; right:8px; border:0; background:#fff; width:32px; height:32px; border-radius:9999px; cursor:pointer; box-shadow:0 1px 6px rgba(0,0,0,.2)}
   .linkish{cursor:pointer; text-decoration:underline}
   </style>
+  <div class="security-notice"><span class="lock-icon">🔒</span> Tus datos se transmiten de forma segura</div>
   <a id="pago"></a>
 <form action="/orden/<?=$order['code']?>/pago" method="post" enctype="multipart/form-data">
     <?= CSRF::field() ?>
@@ -64,7 +65,14 @@
         </div>
         <div id="vesGroup" style="display:none"><label>Monto Bs.</label><input class="input" name="amount_ves" value="<?= number_format($amount_ves, 2, '.', '') ?>" readonly></div>
         <div id="usdGroup" style="display:none"><label>Monto $</label><input class="input" name="amount_usd" value="<?= number_format($amount_usd, 2, '.', '') ?>" readonly></div>
-        <div><label>Referencia</label><input class="input" name="reference"><p class="small" style="margin-top:6px; opacity:.8">Al enviar el pago, la verificación puede tomar hasta 2 horas.</p></div>
+        <div>
+          <label>Referencia</label>
+          <input class="input" name="reference">
+          <div class="verification-info small">
+            <span class="info-icon" tabindex="0">ℹ️</span>
+            <div class="tooltip">La verificación se realiza manualmente y puede tardar hasta 2 horas.</div>
+          </div>
+        </div>
       </div>
       <div class="col-right" style="display:grid; gap:12px">
         <div id="paymentDetails" class="small"></div>

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -553,3 +553,28 @@ h2 { font-weight: 700; font-size: clamp(24px, 3vw, 34px); line-height: 1.15; }
 /* Title inside toolbar */
 .ticket-toolbar{ display:flex; flex-direction:column; align-items:flex-start; gap:8px; }
 .ticket-toolbar .section-title{ margin:0; font-weight:600; opacity:.95; }
+
+/* Payment security notice */
+.security-notice{ display:flex; align-items:center; gap:6px; font-size:12px; color:var(--muted); margin:8px 0; }
+.security-notice .lock-icon{ font-size:14px; }
+
+/* Manual verification tooltip */
+.verification-info{ position:relative; display:inline-flex; align-items:center; gap:4px; color:var(--muted); margin-top:6px; }
+.verification-info .info-icon{ cursor:pointer; }
+.verification-info .tooltip{
+  display:none;
+  position:absolute;
+  left:0;
+  top:100%;
+  margin-top:4px;
+  width:220px;
+  background:var(--panel, var(--card));
+  color:var(--text, var(--txt));
+  border:1px solid var(--border);
+  border-radius:8px;
+  padding:8px;
+  box-shadow:0 4px 12px rgba(0,0,0,.08);
+  z-index:30;
+}
+.verification-info:hover .tooltip,
+.verification-info:focus-within .tooltip{ display:block; }


### PR DESCRIPTION
## Summary
- show lock icon and secure transmission note on payment form
- add tooltip describing manual payment verification process
- style security notice and tooltip

## Testing
- `php -l app/Views/public/order_show.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4a6f9aa7483249ed5a6fc608bf917