### PR TITLE
Refactor RaffleController ticket initialization

### DIFF
--- a/app/Controllers/RaffleController.php
+++ b/app/Controllers/RaffleController.php
@@ -6,15 +6,32 @@ require_once APP_PATH . "/Models/Ticket.php";
 require_once APP_PATH . "/Models/Setting.php";
 
 class RaffleController extends Controller {
-  public function show($id) {
-    $r = new Raffle(); $t = new Ticket();
-$t = new Ticket(); $t->releaseExpiredReservations(15);
+    public function show($id) {
+        $r = new Raffle();
+        $t = new Ticket();
+        $t->releaseExpiredReservations(15);
+
         $raffle = $r->find($id);
-if (!$raffle) { http_response_code(404); echo "Rifa no encontrada"; return; }
-$tickets = $t->allByRaffle($id);
-$bcv = floatval((new Setting())->getBcvRateAuto());
-// Fallback: si no existen tickets (seed no corrió), crear automáticamente
-if (empty($tickets)) { (new Ticket())->createBatch($id, (int)$raffle['total_tickets']); $tickets = $t->allByRaffle($id); }
-$this->view('public/raffle_show.php', ['raffle'=>$raffle, 'tickets'=>$tickets, 'bcv'=>$bcv]);
+        if (!$raffle) {
+            http_response_code(404);
+            echo "Rifa no encontrada";
+            return;
+        }
+
+        $tickets = $t->allByRaffle($id);
+        $bcv = floatval((new Setting())->getBcvRateAuto());
+
+        // Fallback: si no existen tickets (seed no corrió), crear automáticamente
+        if (empty($tickets)) {
+            (new Ticket())->createBatch($id, (int)$raffle['total_tickets']);
+            $tickets = $t->allByRaffle($id);
+        }
+
+        $this->view('public/raffle_show.php', [
+            'raffle' => $raffle,
+            'tickets' => $tickets,
+            'bcv' => $bcv,
+        ]);
+    }
 }
-}
+


### PR DESCRIPTION
## Summary
- streamline raffle view logic by removing duplicate Ticket instantiation
- format RaffleController for clarity and readability

## Testing
- `php -l app/Controllers/RaffleController.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4a2e733248324a2646f42b3ce2091