### PR TITLE
Regenerate session ID on login

### DIFF
--- a/app/Core/Auth.php
+++ b/app/Core/Auth.php
@@ -12,6 +12,7 @@ class Auth {
   }
   public static function login($user) {
     self::start();
+    session_regenerate_id(true);
     $_SESSION['user'] = $user;
   }
   public static function logout() {


### PR DESCRIPTION
## Summary
- Regenerate PHP session ID after starting the session to prevent fixation attacks before storing the user

## Testing
- `php -l app/Core/Auth.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4a2ed74b08324822e77f1eb9f7a02