### PR TITLE
Secure admin seeding via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ Proyecto listo para subir a hosting compartido (Apache + PHP 8.2 + MySQL).
 5. Asegura permisos de escritura para:
    - `storage/uploads/receipts`
    - `storage/logs`
-6. Accede a `/admin` y entra con: **admin@example.com / Admin123!**
+6. Define `ADMIN_SETUP_TOKEN` en `config/.env` y crea el primer administrador visitando  
+   `/admin/seed-admin?token=EL_TOKEN&email=admin@tu-dominio.com&password=TuClaveSegura`.
+7. Elimina `ADMIN_SETUP_TOKEN` (y las credenciales de seed si las agregaste) y accede a  
+   `/admin` con las credenciales creadas.
 
 ## Notas de producción
 - Si la conexión MySQL falla, se mostrará una página de mantenimiento y `/health` devolverá 500.
@@ -29,7 +32,13 @@ Proyecto listo para subir a hosting compartido (Apache + PHP 8.2 + MySQL).
 - **QR**: Se usan imágenes de `api.qrserver.com` (sin clave). Puedes reemplazar por una librería local si lo prefieres.
 
 ## Esquema de BD y seed
-Ver `database.sql`. Se crea un usuario admin por defecto y 2 rifas de ejemplo. Para cada rifa nueva, el sistema genera los boletos secuencialmente.
+Ver `database.sql`. Se crean 2 rifas de ejemplo. Para cada rifa nueva, el sistema genera los boletos secuencialmente.
+
+## Creación de administradores
+1. Establece `ADMIN_SETUP_TOKEN` en `config/.env`. Opcionalmente puedes definir `ADMIN_SEED_EMAIL` y `ADMIN_SEED_PASSWORD`.
+2. Visita `/admin/seed-admin?token=EL_TOKEN` agregando `email` y `password` como parámetros si no los definiste en el `.env`.
+3. Tras el mensaje de éxito, elimina `ADMIN_SETUP_TOKEN` y las credenciales de seed para deshabilitar la ruta.
+4. Ingresa a `/admin` con las credenciales creadas.
 
 ## Rutas principales
 **Público**

--- a/app/Controllers/Admin/AuthController.php
+++ b/app/Controllers/Admin/AuthController.php
@@ -46,9 +46,14 @@ class AuthController extends Controller {
       echo "Forbidden";
       return;
     }
-    $email = 'villalonga.2000@gmail.com';
-    $password = 'Rich@rd932';
-    $name = 'Villalonga Admin';
+    $email = $_GET['email'] ?? ($_ENV['ADMIN_SEED_EMAIL'] ?? '');
+    $password = $_GET['password'] ?? ($_ENV['ADMIN_SEED_PASSWORD'] ?? '');
+    $name = $_GET['name'] ?? ($_ENV['ADMIN_SEED_NAME'] ?? 'Admin');
+
+    if (!$email || !$password) {
+      echo "Missing email or password";
+      return;
+    }
 
     $u = (new User())->findByEmail($email);
     if ($u) { echo "User already exists (id={$u['id']})"; return; }

--- a/config/env.sample
+++ b/config/env.sample
@@ -14,3 +14,6 @@ BCV_SOURCE_URL=https://ve.dolarapi.com/v1/dolares/oficial
 BCV_DEFAULT_RATE=40
 APP_ENV=production
 APP_DEBUG=false
+ADMIN_SETUP_TOKEN=
+ADMIN_SEED_EMAIL=
+ADMIN_SEED_PASSWORD=

--- a/database.sql
+++ b/database.sql
@@ -98,9 +98,6 @@ CREATE TABLE settings (
 ) ENGINE=InnoDB;
 
 -- Seeds
-INSERT INTO users (name,email,password_hash) VALUES
-('Admin','admin@example.com','$2b$12$burdDAqBZOpClSAhHz5sgebvOzvm8trug2uX469bZCfPJt102i/N2');
-
 INSERT INTO raffles (title,description,prize,price_usd,price_ves,total_tickets,sold_tickets,banner_path,status,starts_at,ends_at) VALUES
 ('Rifa iPhone 14','Participa por un iPhone 14 nuevo','iPhone 14',5.00,200.00,100,0,NULL,'activa',NOW(),DATE_ADD(NOW(), INTERVAL 30 DAY)),
 ('Rifa PlayStation 5','Gana una PS5 edición digital','PlayStation 5',4.00,160.00,80,0,NULL,'activa',NOW(),DATE_ADD(NOW(), INTERVAL 30 DAY));
@@ -125,9 +122,4 @@ CALL seed_tickets(@rid1, 100);
 CALL seed_tickets(@rid2, 80);
 DROP PROCEDURE seed_tickets;
 
--- Tasa BCV por defecto
 INSERT INTO settings (skey,svalue) VALUES ('bcv_rate','40');
-
--- Extra admin seed
-INSERT INTO users (name,email,password_hash) VALUES
-('Villalonga','villalonga.2000@gmail.com','$2b$12$hsQJut7pPNnCdbzv1c8jiuV6.wR8rasosRbYs9bay7yV0qqf8ZZrW');

--- a/public/index.php
+++ b/public/index.php
@@ -27,7 +27,9 @@ $router->get('/file/receipt/{name}', ['FileController','receipt']);
 $router->get('/file/site/{name}', ['FileController','site']);
 
 // Admin
-$router->get('/admin/seed-admin', ['AuthController','seedAdmin']);
+if (!empty($_ENV['ADMIN_SETUP_TOKEN'])) {
+  $router->get('/admin/seed-admin', ['AuthController','seedAdmin']);
+}
 $router->get('/admin/login', ['AuthController','loginForm']);
 $router->post('/admin/login', ['AuthController','login']);
 $router->post('/admin/logout', ['AuthController','logout']);


### PR DESCRIPTION
## Summary
- Read admin seeding email and password from environment variables or query parameters instead of hard-coded values
- Register admin seeding route only when `ADMIN_SETUP_TOKEN` is defined and document the process
- Remove default admin seeds and update environment sample and README

## Testing
- `php -l app/Controllers/Admin/AuthController.php`
- `php -l public/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4a310d87c8324a690307d9fca1b96