### PR TITLE
Use POST and CSRF validation for BCV update

### DIFF
--- a/app/Controllers/Admin/SettingsController.php
+++ b/app/Controllers/Admin/SettingsController.php
@@ -121,6 +121,7 @@ class SettingsController extends Controller {
 
   public function updateRate() {
     if (!Auth::check()) { $this->redirect('/admin/login'); }
+    CSRF::validate();
     $s = new Setting();
     $rate = (new Setting())->getBcvRateAuto();
     $s->set('bcv_rate', (string)$rate);

--- a/app/Views/admin/settings/index.php
+++ b/app/Views/admin/settings/index.php
@@ -13,7 +13,11 @@
       <label>Tasa BCV</label>
       <input class="input" name="bcv_rate" value="<?=Utils::e($bcv)?>" />
       <p class="small">Puedes configurar SMTP en config/.env para envío de correos.</p>
-      <p><a class="btn btn-ghost" href="/admin/ajustes/actualizar-bcv">Actualizar desde API</a></p>
+      <p>
+        <button class="btn btn-ghost" type="submit" formaction="/admin/ajustes/actualizar-bcv" formmethod="post">
+          Actualizar desde API
+        </button>
+      </p>
     </div>
     <hr style="border-color:var(--border);opacity:.5;margin:16px 0">
     <div class="form-group">

--- a/public/index.php
+++ b/public/index.php
@@ -45,5 +45,5 @@ $router->post('/admin/pagos/{id}/rechazar', ['PaymentsController','reject']);
 $router->get('/admin/reportes', ['ReportsController','index']);
 $router->get('/admin/ajustes', ['SettingsController','index']);
 $router->post('/admin/ajustes', ['SettingsController','save']);
-$router->get('/admin/ajustes/actualizar-bcv', ['SettingsController','updateRate']);
+$router->post('/admin/ajustes/actualizar-bcv', ['SettingsController','updateRate']);
 $router->dispatch();


### PR DESCRIPTION
## Summary
- switch BCV update endpoint to POST and require CSRF
- add CSRF validation in SettingsController::updateRate
- post BCV rate update via dedicated form button

## Testing
- `php -l public/index.php`
- `php -l app/Controllers/Admin/SettingsController.php`
- `php -l app/Views/admin/settings/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4a301ae4c83249bb3d214c68b32e5