### PR TITLE
Ensure unique payment references

### DIFF
--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -16,6 +16,11 @@ class Payment extends BaseModel {
     $st->execute([$order_id]);
     return $st->fetchAll();
   }
+  public function referenceExists($reference) {
+    $st = $this->db->prepare("SELECT 1 FROM payments WHERE reference=? LIMIT 1");
+    $st->execute([$reference]);
+    return (bool)$st->fetchColumn();
+  }
   public function setStatus($id,$status,$user_id=null) {
     $st = $this->db->prepare("UPDATE payments SET status=?, reviewed_by=?, reviewed_at=NOW() WHERE id=?");
     $st->execute([$status,$user_id,$id]);

--- a/database.sql
+++ b/database.sql
@@ -73,6 +73,7 @@ CREATE TABLE payments (
   reviewed_by INT NULL,
   reviewed_at DATETIME NULL,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE KEY uq_payments_reference (reference),
   CONSTRAINT fk_payments_orders FOREIGN KEY (order_id) REFERENCES orders(id) ON DELETE CASCADE,
   CONSTRAINT fk_payments_users FOREIGN KEY (reviewed_by) REFERENCES users(id) ON DELETE SET NULL
 ) ENGINE=InnoDB;


### PR DESCRIPTION
## Summary
- enforce unique payment references in schema
- check for existing references before creating payments
- handle duplicate reference errors during payment upload

## Testing
- `php -l app/Models/Payment.php`
- `php -l app/Controllers/OrderController.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4ba7f479483249d2f11824d657fb2