### PR TITLE
Require payment receipt on order payment upload

### DIFF
--- a/app/Controllers/OrderController.php
+++ b/app/Controllers/OrderController.php
@@ -99,23 +99,27 @@ $r = new Raffle(); $t = new Ticket(); $o = new Order(); $s = new Setting(); $a =
     $bcvLive = (new Setting())->getBcvRateAuto();
     $amount_usd = floatval($order['total_usd']);
     $amount_ves = floatval($order['total_usd'] * $bcvLive);
-if (!empty($_FILES['receipt']['name'])) {
-      $allowed = ['image/jpeg'=>'jpg','image/png'=>'png','image/webp'=>'webp'];
-      $type = mime_content_type($_FILES['receipt']['tmp_name']);
-      $size = $_FILES['receipt']['size'];
-      if (!isset($allowed[$type]) || $size > 5*1024*1024) {
-        $this->view('public/error.php',['message'=>'Archivo inválido. Solo jpg/png/webp, máximo 5MB.']);
-        return;
-      }
-      $ext = $allowed[$type];
-      $fname = 'order_' . $order['code'] . '_' . time() . '.' . $ext;
-      $dest = UPLOADS_PATH . '/' . $fname;
-      if (!move_uploaded_file($_FILES['receipt']['tmp_name'], $dest)) {
-        $this->view('public/error.php',['message'=>'Error subiendo archivo.']);
-        return;
-      }
-      $receipt_path = $fname;
+
+    if (empty($_FILES['receipt']['name'] ?? '')) {
+      $this->view('public/error.php', ['message' => 'Debe adjuntar el comprobante.']);
+      return;
     }
+
+    $allowed = ['image/jpeg'=>'jpg','image/png'=>'png','image/webp'=>'webp'];
+    $type = mime_content_type($_FILES['receipt']['tmp_name']);
+    $size = $_FILES['receipt']['size'];
+    if (!isset($allowed[$type]) || $size > 5*1024*1024) {
+      $this->view('public/error.php',['message'=>'Archivo inválido. Solo jpg/png/webp, máximo 5MB.']);
+      return;
+    }
+    $ext = $allowed[$type];
+    $fname = 'order_' . $order['code'] . '_' . time() . '.' . $ext;
+    $dest = UPLOADS_PATH . '/' . $fname;
+    if (!move_uploaded_file($_FILES['receipt']['tmp_name'], $dest)) {
+      $this->view('public/error.php',['message'=>'Error subiendo archivo.']);
+      return;
+    }
+    $receipt_path = $fname;
 
     $pid = (new Payment())->create($order['id'], [
       'method'=>$method, 'amount_ves'=>$amount_ves, 'amount_usd'=>$amount_usd,

--- a/app/Views/public/order_show.php
+++ b/app/Views/public/order_show.php
@@ -92,7 +92,7 @@
         <div class="uploadbox" style="padding:12px; border:1px dashed #d1d5db; border-radius:12px; background:#f9fafb">
           <div style="font-weight:600; margin-bottom:6px">Comprobante</div>
           <p class="small" style="margin:6px 0 10px; opacity:.8">Adjunta la imagen del pago (JPG, PNG o WEBP, máx. 5MB).</p>
-          <input id="receiptInput" type="file" name="receipt" accept="image/*" style="display:none">
+          <input id="receiptInput" type="file" name="receipt" accept="image/*" style="display:none" required>
           <div style="display:flex; gap:10px; align-items:center">
             <label for="receiptInput" class="btn-slim" style="display:inline-block; padding:8px 12px; border:1px solid #e5e7eb; border-radius:10px; background:white; cursor:pointer">Seleccionar archivo</label>
             <span id="receiptName" class="small" style="opacity:.8">Ningún archivo seleccionado</span>


### PR DESCRIPTION
## Summary
- Require payment receipt upload in order payment form
- Validate presence of receipt in `uploadPayment` and process uploaded file

## Testing
- `php -l app/Views/public/order_show.php`
- `php -l app/Controllers/OrderController.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4ba6d2bac8324a4c4fa95bdd92bff