### PR TITLE
Auto load tickets after receipt upload

### DIFF
--- a/app/Core/PDF.php
+++ b/app/Core/PDF.php
@@ -1,9 +1,7 @@
 <?php
 class PDF {
-  // Very basic PDF generator as a fallback when Dompdf is not available.
-  // Renders a simple receipt PDF without CSS. For richer output, drop-in dompdf in vendor/ and it will be used automatically.
   public static function receipt($html, $filename='comprobante.pdf') {
-    // If dompdf exists, use it
+    $pdfContent = null;
     if (file_exists(BASE_PATH . '/vendor/autoload.php')) {
       require_once BASE_PATH . '/vendor/autoload.php';
       if (class_exists('Dompdf\Dompdf')) {
@@ -11,15 +9,43 @@ class PDF {
         $dompdf->loadHtml($html, 'UTF-8');
         $dompdf->setPaper('A4', 'portrait');
         $dompdf->render();
-        header('Content-Type: application/pdf');
-        header('Content-Disposition: inline; filename="'.$filename.'"');
-        echo $dompdf->output();
-        return;
+        $pdfContent = $dompdf->output();
       }
     }
-    // Basic fallback: wrap HTML inside a minimal PDF (text only). We'll just force download of HTML as .pdf
-    header('Content-Type: application/octet-stream');
-    header('Content-Disposition: attachment; filename="'.$filename.'"');
-    echo $html;
+    if ($pdfContent === null) {
+      $text = trim(strip_tags($html));
+      $pdfContent = self::basicTextPdf($text);
+    }
+    if (empty($pdfContent)) {
+      throw new RuntimeException('No PDF generated');
+    }
+    header('Content-Type: application/pdf');
+    header('Content-Disposition: inline; filename="'.$filename.'"');
+    echo $pdfContent;
+  }
+
+  private static function basicTextPdf($text) {
+    $text = str_replace(['\\', '(', ')'], ['\\\\', '\\(', '\\)'], $text);
+    $content = "BT /F1 12 Tf 50 750 Td (".$text.") Tj ET";
+    $objects = [];
+    $objects[] = "<< /Type /Catalog /Pages 2 0 R >>";
+    $objects[] = "<< /Type /Pages /Kids [3 0 R] /Count 1 >>";
+    $objects[] = "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>";
+    $objects[] = "<< /Length ".strlen($content)." >>\nstream\n".$content."\nendstream";
+    $objects[] = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>";
+    $pdf = "%PDF-1.4\n";
+    $offsets = [];
+    foreach ($objects as $i => $obj) {
+      $offsets[$i+1] = strlen($pdf);
+      $pdf .= ($i+1)." 0 obj\n".$obj."\nendobj\n";
+    }
+    $xrefPos = strlen($pdf);
+    $pdf .= "xref\n0 ".(count($objects)+1)."\n";
+    $pdf .= "0000000000 65535 f \n";
+    for ($i=1; $i<=count($objects); $i++) {
+      $pdf .= sprintf("%010d 00000 n \n", $offsets[$i]);
+    }
+    $pdf .= "trailer << /Size ".(count($objects)+1)." /Root 1 0 R >>\nstartxref\n".$xrefPos."\n%%EOF";
+    return $pdf;
   }
 }

--- a/app/Views/public/my_tickets.php
+++ b/app/Views/public/my_tickets.php
@@ -1,5 +1,10 @@
 <h2>Mis boletos</h2>
+<?php if (!empty($justUploaded)): ?>
+<p class="section-subtitle my-sub">Comprobante enviado correctamente. Estos son sus boletos.</p>
+<?php else: ?>
 <p class="section-subtitle my-sub">Encuentra tus participaciones ingresando tu Cédula/DNI.</p>
+<?php endif; ?>
+<?php if (empty($justUploaded)): ?>
 <div class="card">
   <form method="get">
     <div class="form-row">
@@ -9,12 +14,15 @@
   </form>
   <?php if (!empty($error)): ?><p class="small" style="color:var(--danger)"><?=Utils::e($error)?></p><?php endif; ?>
 </div>
+<?php elseif (!empty($error)): ?>
+<div class="card"><p class="small" style="color:var(--danger)"><?=Utils::e($error)?></p></div>
+<?php endif; ?>
 <?php if (!empty($tickets)): ?>
   <div class="grid" style="gap:16px">
     <?php foreach ($tickets as $t): $url = Utils::url('/orden/'.$t['order_code']); ?>
     <div class="card" style="margin:12px">
       <div style="margin-bottom:6px"><strong><?=Utils::e($t['title'])?></strong> — #<?=$t['number']?></div>
-      <?php $isPending = ($t['order_status']==='pendiente'); ?>
+      <?php $isPending = ($t['order_status']==='pendiente'); $hasReceipt = !empty($t['has_receipt']); ?>
       <div class="small" style="margin:6px 0">
         Estado:
         <?php if($t['order_status']==='pagado'): ?>
@@ -29,7 +37,7 @@
         $init_mm = intdiv($rem, 60); $init_ss = $rem % 60;
         $init_text = sprintf('%02d:%02d', $init_mm, $init_ss);
       ?>
-      <?php if ($isPending): ?>
+      <?php if ($isPending && !$hasReceipt): ?>
         <div class="small" style="margin:6px 0">
           Tiempo restante: <span class="countdown" data-seconds="<?=$rem?>"><?=$init_text?></span>
         </div>
@@ -41,10 +49,18 @@
         </a>
       <?php elseif ($t['order_status']==='pagado'): ?>
         <p class="small" style="color:var(--success); margin:6px 0">Pago aprobado.</p>
+      <?php elseif ($isPending && $hasReceipt): ?>
+        <p class="small" style="color:#ca8a04; margin:6px 0">Pago en revisión.</p>
       <?php else: ?>
         <p class="small" style="color:var(--danger); margin:6px 0">Orden expirada o rechazada.</p>
       <?php endif; ?>
-      <p class="small" style="margin-top:8px">Orden: <strong><?=$t['order_code']?></strong></p>
+      <p class="small" style="margin-top:8px">Orden: 
+        <?php if ($hasReceipt): ?>
+          <a href="/orden/<?=$t['order_code']?>/comprobante.pdf"><strong><?=$t['order_code']?></strong></a>
+        <?php else: ?>
+          <strong><?=$t['order_code']?></strong>
+        <?php endif; ?>
+      </p>
     </div>
     <?php endforeach; ?>
   </div>


### PR DESCRIPTION
## Summary
- Store DNI after receipt upload and auto-display tickets on `/mis-boletos`
- Hide payment controls when a receipt exists and link order code to downloadable PDF
- Generate receipt PDFs even without Dompdf and show errors if generation fails

## Testing
- `php -l app/Controllers/OrderController.php`
- `php -l app/Views/public/my_tickets.php`
- `php -l app/Core/PDF.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4c6ea6da48324b9159be76d0fddb2