### PR TITLE
Remove QR references and sanitize receipt PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Proyecto listo para subir a hosting compartido (Apache + PHP 8.2 + MySQL).
 - **PDF**: Incluimos un generador básico de respaldo. Para PDF con HTML/CSS completo y adjuntos por correo, agrega `vendor/` con **dompdf** y (opcional) **PHPMailer**:
   - Descarga `dompdf/dompdf` y `phpmailer/phpmailer` con Composer en tu equipo y sube el directorio `vendor/` resultante junto con `vendor/autoload.php`.
   - El sistema detecta automáticamente Dompdf si está disponible.
-- **QR**: Se usan imágenes de `api.qrserver.com` (sin clave). Puedes reemplazar por una librería local si lo prefieres.
 
 ## Esquema de BD y seed
 Ver `database.sql`. Se crean 2 rifas de ejemplo. Para cada rifa nueva, el sistema genera los boletos secuencialmente.
@@ -49,7 +48,7 @@ Ver `database.sql`. Se crean 2 rifas de ejemplo. Para cada rifa nueva, el sistem
 - `POST /orden/{code}/pago` — carga de comprobante (jpg/png/webp máx 5MB).
 - `GET /orden/{code}/comprobante` — HTML del comprobante.
 - `GET /orden/{code}/comprobante.pdf` — PDF (Dompdf si está disponible).
-- `GET /mis-boletos?email=...&code=...` — listado de boletos con QR.
+- `GET /mis-boletos?email=...&code=...` — listado de boletos.
 
 **Admin**
 - `GET /admin/login`, `POST /admin/login`, `POST /admin/logout`

--- a/app/Core/PDF.php
+++ b/app/Core/PDF.php
@@ -13,7 +13,9 @@ class PDF {
       }
     }
     if ($pdfContent === null) {
-      $text = trim(strip_tags($html));
+      // Remove style/script blocks to avoid exposing raw CSS when Dompdf is absent
+      $clean = preg_replace('#<(style|script)[^>]*>.*?</\\1>#si', '', $html);
+      $text  = trim(strip_tags($clean));
       $pdfContent = self::basicTextPdf($text);
     }
     if (empty($pdfContent)) {

--- a/app/Views/public/my_tickets.php
+++ b/app/Views/public/my_tickets.php
@@ -55,9 +55,6 @@
           <p style="margin:8px 0 8px">
             <a class="btn btn-primary" href="/orden/<?= $t['order_code'] ?>#pago" aria-label="Ir a pago" style="margin:6px 0; display:inline-block">Pagar ahora</a>
           </p>
-          <a href="/orden/<?= $t['order_code'] ?>#pago" aria-label="Ir a pago" style="display:inline-block; margin-top:6px">
-            <img src="https://api.qrserver.com/v1/create-qr-code/?size=140x140&data=<?= urlencode($url) ?>" alt="QR">
-          </a>
         <?php elseif ($t['order_status'] === 'pagado'): ?>
           <p class="small" style="color:var(--success); margin:6px 0">Pago aprobado.</p>
         <?php elseif ($isPending && $hasReceipt): ?>

--- a/app/Views/public/order_show.php
+++ b/app/Views/public/order_show.php
@@ -21,12 +21,11 @@
 <div class="card">
   <h3 class="card-title">Boletos</h3>
   <table class="table card-table">
-    <tr><th>Rifa</th><th>#</th><th>QR</th></tr>
-    <?php require_once APP_PATH . '/Models/Setting.php'; foreach ($items as $it): $url = Utils::url('/orden/'.$order['code']); ?>
+    <tr><th>Rifa</th><th>#</th></tr>
+    <?php foreach ($items as $it): ?>
       <tr>
         <td><?=Utils::e($it['title'])?></td>
         <td>#<?=$it['number']?></td>
-        <td><img src="https://api.qrserver.com/v1/create-qr-code/?size=80x80&data=<?=urlencode($url)?>" alt="QR"></td>
       </tr>
     <?php endforeach; ?>
   </table>

--- a/app/Views/public/receipt.php
+++ b/app/Views/public/receipt.php
@@ -8,9 +8,9 @@
   <p><strong>Total:</strong> $<?=Utils::money($order['total_usd'])?> / Bs. <?=Utils::money($order['total_ves'])?></p>
   <h3>Boletos</h3>
   <ul>
-    <?php foreach ($items as $it): $url = Utils::url('/orden/'.$order['code']); ?>
-      <li><?=Utils::e($it['title'])?> — #<?=$it['number']?> — <img src="https://api.qrserver.com/v1/create-qr-code/?size=80x80&data=<?=urlencode($url)?>" alt="QR"></li>
+    <?php foreach ($items as $it): ?>
+      <li><?=Utils::e($it['title'])?> — #<?=$it['number']?></li>
     <?php endforeach; ?>
   </ul>
-  <p style="font-size:12px;color:#555">Escanea el QR para ver tu orden: <?=Utils::url('/orden/'.$order['code'])?></p>
+  <p style="font-size:12px;color:#555">Consulta tu orden en: <?=Utils::url('/orden/'.$order['code'])?></p>
 </div>

--- a/app/Views/public/receipt_pdf.php
+++ b/app/Views/public/receipt_pdf.php
@@ -1,2 +1,12 @@
-<?php ob_start(); include APP_PATH . '/Views/public/receipt.php'; $inner = ob_get_clean(); ?>
-<!doctype html><html><head><meta charset="utf-8"><style>body{font-family:Arial,Helvetica,sans-serif}</style></head><body><?=$inner?></body></html>
+<?php
+ob_start();
+include APP_PATH . '/Views/public/receipt.php';
+$inner = ob_get_clean();
+?>
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+</head>
+<body><?=$inner?></body>
+</html>


### PR DESCRIPTION
## Summary
- Strip style/script blocks before generating fallback PDF receipts
- Remove all QR code images and mentions from public views and docs

## Testing
- `php -l app/Core/PDF.php`
- `php -l app/Views/public/receipt_pdf.php`
- `php -l app/Views/public/receipt.php`
- `php -l app/Views/public/order_show.php`
- `php -l app/Views/public/my_tickets.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4d298a3b88324900af42ccecff643