### PR TITLE
Remove unsupported transfer payment option

### DIFF
--- a/app/Controllers/OrderController.php
+++ b/app/Controllers/OrderController.php
@@ -136,7 +136,7 @@ class OrderController extends Controller {
     }
 
     // Valida método contra lista conocida (ajusta según tus métodos)
-    $allowedMethods = ['pago_movil', 'transferencia', 'zelle', 'efectivo'];
+    $allowedMethods = ['pago_movil','zelle','binance','efectivo'];
     $method = $_POST['method'] ?? 'pago_movil';
     if (!in_array($method, $allowedMethods, true)) { $method = 'pago_movil'; }
 


### PR DESCRIPTION
## Summary
- Align order payment method list with UI and database
- Remove legacy `transferencia` method from server validation

## Testing
- `php -l app/Controllers/OrderController.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4f6c290a48324b06f098eec29a614