### PR TITLE
Escape order status output

### DIFF
--- a/app/Views/public/order_show.php
+++ b/app/Views/public/order_show.php
@@ -10,7 +10,7 @@
   $remaining = isset($remaining) ? (int)$remaining : 0;
   $expiry_ts = time() + $remaining;
   ?>
-<p><strong>Estado:</strong> <span class="tag"><?=$order['status']?></span></p>
+<p><strong>Estado:</strong> <span class="tag"><?=Utils::e($order['status'])?></span></p>
   <?php if ($order['status']==='pendiente'): ?>
   <div id="countdownBox" class="alert countdown-box countdown-box--minimal" role="status" aria-live="polite">
     Tiempo restante para pagar: <strong><span id="countdown" data-expiry="<?=$expiry_ts?>" aria-live="polite"></span></strong>


### PR DESCRIPTION
## Summary
- Sanitize order status in order view using Utils::e to avoid injection

## Testing
- `php -l app/Views/public/order_show.php`

------
https://chatgpt.com/codex/tasks/task_e_68a4f6c4797083248167b0c14877c282