### PR TITLE
refactor: move order payment grid styles to css

### DIFF
--- a/app/Views/public/order_show.php
+++ b/app/Views/public/order_show.php
@@ -46,8 +46,8 @@
   <a id="pago"></a>
 <form action="/orden/<?=$order['code']?>/pago" method="post" enctype="multipart/form-data">
     <?= CSRF::field() ?>
-<div class="form-grid" style="display:grid; grid-template-columns: 1fr 1fr; gap:16px; align-items:start">
-      <div class="col-left" style="display:grid; gap:12px">
+<div class="form-grid order-form-grid">
+      <div class="col-left order-column-left">
         <div>
           <label>Método</label>
           <select name="method">
@@ -66,7 +66,7 @@
           </div>
         </div>
       </div>
-      <div class="col-right" style="display:grid; gap:12px">
+      <div class="col-right order-column-right">
         <div id="paymentDetails" class="small payment-details payment-details--minimal" data-paybox-variant="minimal" role="region" aria-label="Detalles del pago"></div>
         <div class="uploadbox uploadbox--minimal" role="group" aria-labelledby="receiptLabel" aria-describedby="receiptHelp">
           <div id="receiptLabel" class="uploadbox__title">Comprobante</div>

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -60,6 +60,20 @@ label{font-size:13px;color:var(--muted);margin-bottom:6px;display:block}
 .ticket input:checked + .pill{outline:2px solid var(--accent); box-shadow:0 0 0 2px rgba(125,211,252,.35) inset;}
 .form-row .form-group{margin-bottom:14px}
 
+/* Order payment form */
+.order-form-grid{
+  display:grid;
+  grid-template-columns:1fr 1fr;
+  gap:16px;
+  align-items:start;
+}
+.order-column-left,
+.order-column-right{
+  display:grid;
+  gap:12px;
+}
+
+
 /* ====== Raffle detail layout (clean) ====== */
 .form-row{display:grid;grid-template-columns:1.4fr .8fr;gap:24px;align-items:flex-start}
 @media (max-width: 980px){.form-row{grid-template-columns:1fr;gap:16px}}


### PR DESCRIPTION
## Summary
- replace inline grid styles in order payment form with dedicated CSS classes
- add `.order-form-grid`, `.order-column-left`, `.order-column-right` styles to stylesheet

## Testing
- `php -l app/Views/public/order_show.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4f6ec81388324bfa71485ce343dd3