### PR TITLE
feat: make admin layout mobile friendly

### DIFF
--- a/app/Views/layouts/admin.php
+++ b/app/Views/layouts/admin.php
@@ -9,7 +9,7 @@
 <body>
   <div class="nav">
     <div class="logo"><a href="/admin">🛠️ Admin</a></div>
-    <div><a href="/admin/rifas" class="btn">Rifas</a> <a href="/admin/ordenes" class="btn">Órdenes</a> <a href="/admin/reportes" class="btn">Reportes</a> <a href="/admin/ajustes" class="btn">Ajustes</a> <form action="/admin/logout" method="post" style="display:inline"><?php require_once APP_PATH.'/Core/CSRF.php'; echo CSRF::field(); ?><button class="btn">Salir</button></form></div>
+    <div class="nav-links"><a href="/admin/rifas" class="btn">Rifas</a> <a href="/admin/ordenes" class="btn">Órdenes</a> <a href="/admin/reportes" class="btn">Reportes</a> <a href="/admin/ajustes" class="btn">Ajustes</a> <form action="/admin/logout" method="post" style="display:inline"><?php require_once APP_PATH.'/Core/CSRF.php'; echo CSRF::field(); ?><button class="btn">Salir</button></form></div>
   </div>
   <div class="container">
     <?= $content ?>

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -33,6 +33,7 @@ html,body{
 a{color:var(--accent);text-decoration:none}
 .container{max-width:clamp(1100px, 92vw, 1320px);margin:0 auto;padding:24px}
 .nav{display:flex;justify-content:space-between;align-items:center;padding:16px 24px;backdrop-filter: blur(8px);background:rgba(255,255,255,.04);border-bottom:1px solid var(--border);position:sticky;top:0;z-index:10}
+.nav-links{display:flex;gap:10px;align-items:center;flex-wrap:wrap}
 .logo{font-weight:700;letter-spacing:.4px}
 .btn{padding:10px 16px;border:1px solid var(--border);background:var(--card);color:var(--txt);border-radius:12px;cursor:pointer;transition:.2s transform,.2s background,.2s box-shadow}
 .btn:hover{transform:translateY(-2px);box-shadow:0 8px 30px rgba(0,0,0,.2)}
@@ -51,11 +52,17 @@ label{font-size:13px;color:var(--muted);margin-bottom:6px;display:block}
 .form-row{display:grid;grid-template-columns:1fr 1fr;gap:12px}
 .table{width:100%;border-collapse:collapse}
 .table th,.table td{padding:10px;border-bottom:1px solid var(--border)}
-.kpis{display:grid;grid-template-columns:repeat(4,1fr);gap:12px}
+.kpis{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:12px}
 .kpi{padding:16px;background:var(--card);border:1px solid var(--border);border-radius:12px}
 .tag{padding:6px 10px;border-radius:999px;border:1px solid var(--border);font-size:12px}
 .footer{padding:40px;color:var(--muted);text-align:center}
 .small{font-size:12px;color:var(--muted)}
+@media(max-width:600px){
+  .container{padding:16px}
+  .nav{flex-direction:column;align-items:flex-start;padding:12px 16px}
+  .nav-links{width:100%}
+  .table{display:block;overflow-x:auto}
+}
 .ticket .pill{display:flex;align-items:center;justify-content:center;width:100%;height:100%}
 .ticket input:checked + .pill{outline:2px solid var(--accent); box-shadow:0 0 0 2px rgba(125,211,252,.35) inset;}
 .form-row .form-group{margin-bottom:14px}


### PR DESCRIPTION
## Summary
- improve admin navbar layout for small screens
- add responsive grid and media queries for admin interface

## Testing
- `php -l app/Views/layouts/admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68a513e34f388324933dbcedf3cfedc9