### PR TITLE
feat: dynamic admin logo

### DIFF
--- a/app/Views/layouts/admin.php
+++ b/app/Views/layouts/admin.php
@@ -1,6 +1,9 @@
 <?php
 require_once APP_PATH.'/Core/Auth.php';
+require_once APP_PATH . "/Models/Setting.php";
 $user = Auth::user() ?? ['name' => 'Admin'];
+$__s = new Setting();
+$__logo = $__s->get('site_logo', '');
 ?>
 <!doctype html>
 <html lang="es">
@@ -12,7 +15,7 @@ $user = Auth::user() ?? ['name' => 'Admin'];
 <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-900 text-gray-100">
-  <aside id="admin-sidebar" data-user='<?= json_encode($user) ?>' class="peer group fixed left-0 top-0 h-screen w-20 hover:w-64 bg-gray-900 border-r border-gray-800 transition-all duration-300 overflow-hidden flex flex-col"></aside>
+  <aside id="admin-sidebar" data-user='<?= json_encode($user) ?>' data-logo='<?= Utils::e($__logo) ?>' class="peer group fixed left-0 top-0 h-screen w-20 hover:w-64 bg-gray-900 border-r border-gray-800 transition-all duration-300 overflow-hidden flex flex-col"></aside>
   <main class="ml-20 p-4 transition-all duration-300 peer-hover:ml-64">
     <div class="container">
       <?= $content ?>

--- a/public/js/admin-sidebar.js
+++ b/public/js/admin-sidebar.js
@@ -11,7 +11,7 @@ import htm from "https://esm.sh/htm@3?deps=react@18";
 
 const html = htm.bind(React.createElement);
 
-function Sidebar({ user }) {
+function Sidebar({ user, logo }) {
   const menu = [
     { href: "/admin/rifas", label: "Rifas", icon: Ticket },
     { href: "/admin/ordenes", label: "Órdenes", icon: ShoppingCart },
@@ -24,7 +24,7 @@ function Sidebar({ user }) {
   return html`
     <div class="flex flex-col h-full">
       <div class="flex items-center justify-center h-16 border-b border-gray-800">
-        <img src="/images/logo.svg" alt="Logo" class="w-10 h-10" />
+        <img src=${logo ? `/file/site/${logo}` : "/images/logo.svg"} alt="Logo" class="w-10 h-10" />
       </div>
       <div class="flex flex-col items-center mt-4">
         <img
@@ -65,4 +65,5 @@ function Sidebar({ user }) {
 
 const container = document.getElementById("admin-sidebar");
 const user = JSON.parse(container.dataset.user || "{}");
-createRoot(container).render(html`<${Sidebar} user=${user} />`);
+const logo = container.dataset.logo || "";
+createRoot(container).render(html`<${Sidebar} user=${user} logo=${logo} />`);


### PR DESCRIPTION
## Summary
- pass site logo setting to admin sidebar via data attribute
- render configured logo in sidebar with default fallback

## Testing
- `php -l app/Views/layouts/admin.php`
- `node --check public/js/admin-sidebar.js`


------
https://chatgpt.com/codex/tasks/task_e_68a5c87ddb288324afdd66b88e13a1cd