### PR TITLE
Sanitize admin sidebar user data

### DIFF
--- a/app/Views/layouts/admin.php
+++ b/app/Views/layouts/admin.php
@@ -12,7 +12,7 @@ $user = Auth::user() ?? ['name' => 'Admin'];
 <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-900 text-gray-100">
-  <aside id="admin-sidebar" data-user='<?= json_encode($user) ?>' class="peer group fixed left-0 top-0 h-screen w-20 hover:w-64 bg-gray-900 border-r border-gray-800 transition-all duration-300 overflow-hidden flex flex-col"></aside>
+  <aside id="admin-sidebar" data-user='<?= htmlspecialchars(json_encode($user), ENT_QUOTES, 'UTF-8') ?>' class="peer group fixed left-0 top-0 h-screen w-20 hover:w-64 bg-gray-900 border-r border-gray-800 transition-all duration-300 overflow-hidden flex flex-col"></aside>
   <main class="ml-20 p-4 transition-all duration-300 peer-hover:ml-64">
     <div class="container">
       <?= $content ?>


### PR DESCRIPTION
## Summary
- Escape embedded user JSON in admin layout to prevent breaking the HTML attribute
- Preserve sidebar functionality by verifying the encoded user object still parses correctly

## Testing
- `php -l app/Views/layouts/admin.php`
- `node - <<'NODE'
const encoded = String.raw`{&quot;name&quot;:&quot;Admin \&quot;test\&quot;&quot;,&quot;avatar&quot;:&quot;http:\/\/example.com\/img.png&quot;}`;
function decodeHtml(str) {
  return str
    .replace(/&quot;/g, '"')
    .replace(/&#039;/g, "'")
    .replace(/&lt;/g, '<')
    .replace(/&gt;/g, '>')
    .replace(/&amp;/g, '&');
}
const decoded = decodeHtml(encoded);
console.log(decoded);
console.log(JSON.parse(decoded));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a5c87c91bc8324b3cbf85daea3cad7