### PR TITLE
feat: add noscript fallback sidebar

### DIFF
--- a/app/Views/layouts/admin.php
+++ b/app/Views/layouts/admin.php
@@ -12,7 +12,17 @@ $user = Auth::user() ?? ['name' => 'Admin'];
 <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-900 text-gray-100">
-  <aside id="admin-sidebar" data-user='<?= json_encode($user) ?>' class="peer group fixed left-0 top-0 h-screen w-20 hover:w-64 bg-gray-900 border-r border-gray-800 transition-all duration-300 overflow-hidden flex flex-col"></aside>
+  <aside id="admin-sidebar" data-user='<?= json_encode($user) ?>' class="peer group fixed left-0 top-0 h-screen w-20 hover:w-64 bg-gray-900 border-r border-gray-800 transition-all duration-300 overflow-hidden flex flex-col">
+    <noscript>
+      <nav class="p-4">
+        <ul class="space-y-2">
+          <li><a href="/admin/rifas" class="block py-2">Rifas</a></li>
+          <li><a href="/admin/ordenes" class="block py-2">Órdenes</a></li>
+          <li><a href="/admin/logout" class="block py-2">Salir</a></li>
+        </ul>
+      </nav>
+    </noscript>
+  </aside>
   <main class="ml-20 p-4 transition-all duration-300 peer-hover:ml-64">
     <div class="container">
       <?= $content ?>


### PR DESCRIPTION
## Summary
- provide basic HTML fallback inside admin sidebar when JavaScript is disabled

## Testing
- `php -l app/Views/layouts/admin.php`
- `npm test` *(fails: ENOENT package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c87aa81c8324ac56ad209e0e8836